### PR TITLE
CMake: Add OpenFAST_INCLUDE_DIRS

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,23 +68,6 @@ and restart your terminal.
 
 You're good to go! If you want to re-compile the adapter, make sure to clean the old installation first by running `src/Allclean`.
 
-## Known installation issues
-
-The installation may fail to detect `OpenFAST.H`, causing the installation process to end with the error message
-
-```bash
-fatal error: OpenFAST.H: No such file or directory
-    1 | #include <OpenFAST.H>
-```
-
-One solution is to change the include command in line 1 of `openfast-adapter.cpp` and provide the direct path to the `OpenFAST.H` file of your OpenFAST installation:
-
-```bash
-#include "/yourPath/openfast/install/include/OpenFAST.H"
-```
-
-While in no way perfect, this solution adresses the issue and allows to proceed with the installation.
-
 ## References
 
 A more detailed description of the concept behind the adapter can be found in this [report](https://pure.tudelft.nl/ws/portalfiles/portal/175757249/willeke24-openfast-adapter.pdf). Please consider citing the report if you are using the adapter.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(precice REQUIRED CONFIG)
 add_executable(openfast-adapter ./openfast-adapter.cpp)
 set_target_properties(openfast-adapter PROPERTIES CXX_STANDARD 11)
 
+target_include_directories(openfast-adapter PRIVATE ${OpenFAST_INCLUDE_DIRS})
 target_link_libraries(openfast-adapter PRIVATE aerodyn14lib aerodynlib beamdynlib
  elastodynlib extptfm_mckflib feamlib foamfastlib hydrodynlib icedynlib icefloelib
  ifwlib maplib moordynlib nwtclibs openfastcpplib openfastlib openfast_postlib


### PR DESCRIPTION
Fixes header not found issue for `OpenFAST.H`.