### PR TITLE
Improvements in the case cleaning scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# build directory
+build

--- a/cases/cfd-turbine/fluid/clean.sh
+++ b/cases/cfd-turbine/fluid/clean.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e -u
 
 # Source tutorial clean functions
 . $WM_PROJECT_DIR/bin/tools/CleanFunctions
@@ -6,6 +7,6 @@
 rm -rf 0 > /dev/null 2>&1
 
 cleanCase
-rm -r ./precice-profiling
-rm -r ../precice-run
+rm -rf ./precice-profiling
+rm -rf ../precice-run
 # ----------------------------------------------------------------- end-of-file

--- a/cases/cfd-turbine/openfast/clean.sh
+++ b/cases/cfd-turbine/openfast/clean.sh
@@ -1,12 +1,15 @@
-rm -r ./nrel5mw/*.chkp
-rm -r ./nrel5mw/*.outb
-rm -r ./nrel5mw/*.out
-rm -r ./nrel5mw/*.sum
-rm -r ./nrel5mw/*.ech
-rm -r ./nrel5mw/vtk
-rm -r ./*.h5
-rm -r ./*.bak
-rm -r ./turbineAlloc.0.txt
-rm -r ./*.log
-rm -r ./*.json
-rm -r ./precice-profiling
+#!/usr/bin/env bash
+set -e -u
+
+rm -rf ./nrel5mw/*.chkp
+rm -rf ./nrel5mw/*.outb
+rm -rf ./nrel5mw/*.out
+rm -rf ./nrel5mw/*.sum
+rm -rf ./nrel5mw/*.ech
+rm -rf ./nrel5mw/vtk
+rm -rf ./*.h5
+rm -rf ./*.bak
+rm -rf ./turbineAlloc.0.txt
+rm -rf ./*.log
+rm -rf ./*.json
+rm -rf ./precice-profiling

--- a/cases/dummy-turbine/fluid/clean.sh
+++ b/cases/dummy-turbine/fluid/clean.sh
@@ -1,12 +1,15 @@
-rm -r ./*.log
-rm -r ./*.json
-rm -r ../precice-run
-rm -r ./Testing
-rm -r ./CMakeCache.txt
-rm -r ./cmake_install.cmake
-rm -r ./CTestTestfile.cmake
-rm -r ./fluid-solver
-rm -r ./CMakeFiles
-rm -r ./Makefile
-rm -r ./test.cmake
-rm -r ./precice-profiling
+#!/usr/bin/env bash
+set -e -u
+
+rm -rf ./*.log
+rm -rf ./*.json
+rm -rf ../precice-run
+rm -rf ./Testing
+rm -rf ./CMakeCache.txt
+rm -rf ./cmake_install.cmake
+rm -rf ./CTestTestfile.cmake
+rm -rf ./fluid-solver
+rm -rf ./CMakeFiles
+rm -rf ./Makefile
+rm -rf ./test.cmake
+rm -rf ./precice-profiling

--- a/cases/dummy-turbine/openfast/clean.sh
+++ b/cases/dummy-turbine/openfast/clean.sh
@@ -1,11 +1,14 @@
-rm -r ./nrel5mw/*.chkp
-rm -r ./nrel5mw/*.outb
-rm -r ./nrel5mw/*.out
-rm -r ./nrel5mw/*.sum
-rm -r ./nrel5mw/*.ech
-rm -r ./nrel5mw/vtk
-rm -r ./*.h5
-rm -r ./*.bak
-rm -r ./turbineAlloc.0.txt
-rm -r ./precice-profiling
-rm -r ../precice-run
+#!/usr/bin/env bash
+set -e -u
+
+rm -rf ./nrel5mw/*.chkp
+rm -rf ./nrel5mw/*.outb
+rm -rf ./nrel5mw/*.out
+rm -rf ./nrel5mw/*.sum
+rm -rf ./nrel5mw/*.ech
+rm -rf ./nrel5mw/vtk
+rm -rf ./*.h5
+rm -rf ./*.bak
+rm -rf ./turbineAlloc.0.txt
+rm -rf ./precice-profiling
+rm -rf ../precice-run


### PR DESCRIPTION
- Marks the `clean.sh` scripts as executable.
- Adds a shebang in the scripts that did not have one (they now don't need to be executed as `bash clean.sh`). Also sets the common `-e -u` options for exiting when encountering errors or undefined variables.
- Adds the `-f` flag to the `rm` commands, so that when a file is not found, the scripts do not complain (even if just with a warning).
- Adds the `build` directory to the `.gitignore` (not directly related, but also leads to a cleaner repo :-))