### PR TITLE
Add a workflow to build and test the adapter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - main
       - develop
   workflow_dispatch:
-    
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -49,7 +49,7 @@ jobs:
           ./run.sh &
           PIDOne=$!
           cd ../openfast
-          PATH=../../build/:${PATH} ./run.sh &
+          PATH="../../build/:${PATH}" ./run.sh &
           PIDTwo=$!
           wait $PIDOne
           wait $PIDTwo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           git switch --detach v3.5.3
           mkdir build
           cd build
-          cmake ..
+          cmake -DBUILD_OPENFAST_CPP_API=ON ..
           make -j $(nproc)
           make install
       - name: Build OpenFAST adapter

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get -qq update
-          apt-get -qq install git cmake libblas-dev liblapack-dev gfortran g++
+          apt-get -qq install git cmake libblas-dev liblapack-dev libyaml-cpp-dev gfortran g++
       - name: Build OpenFAST
         run: |
           git clone https://github.com/OpenFAST/OpenFAST.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           ./run.sh &
           PIDOne=$!
           cd ../openfast
-          PATH="../../build/:${PATH}" ./run.sh &
+          PATH="../../../src/build/:${PATH}" ./run.sh &
           PIDTwo=$!
           wait $PIDOne
           wait $PIDTwo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,16 +24,18 @@ jobs:
       - name: Build OpenFAST
         run: |
           git clone https://github.com/OpenFAST/OpenFAST.git
+          pwd && ls
           cd OpenFAST
           git switch --detach v3.5.3
           mkdir build
           cd build
           cmake -DBUILD_OPENFAST_CPP_API=ON ..
-          make -j $(nproc)
-          make install
+          # make -j $(nproc)
+          # make install
       - name: Build OpenFAST adapter
         run: |
           cd src
+          pwd && ls
           mkdir build
           cd build
           OpenFAST_DIR=../OpenFAST/install/lib/cmake/OpenFAST cmake ..

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,21 +24,19 @@ jobs:
       - name: Build OpenFAST
         run: |
           git clone https://github.com/OpenFAST/OpenFAST.git
-          pwd && ls
           cd OpenFAST
           git switch --detach v3.5.3
           mkdir build
           cd build
           cmake -DBUILD_OPENFAST_CPP_API=ON ..
-          # make -j $(nproc)
-          # make install
+          make -j $(nproc)
+          make install
       - name: Build OpenFAST adapter
         run: |
           cd src
-          pwd && ls
           mkdir build
           cd build
-          OpenFAST_DIR=../OpenFAST/install/lib/cmake/OpenFAST cmake ..
+          OpenFAST_DIR=../../OpenFAST/install/lib/cmake/OpenFAST cmake ..
           make -j $(nproc)
       - name: Build dummy-turbine fluid case
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+name: Build and run
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+    
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: precice/precice:nightly
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          apt-get -qq update
+          apt-get -qq install git cmake libblas-dev liblapack-dev gfortran g++
+      - name: Build OpenFAST
+        run: |
+          git clone https://github.com/OpenFAST/OpenFAST.git
+          cd OpenFAST
+          git switch --detach v3.5.3
+          mkdir build
+          cd build
+          cmake ..
+          make -j $(nproc)
+          make install
+      - name: Build OpenFAST adapter
+        run: |
+          cd src
+          mkdir build
+          cd build
+          OpenFAST_DIR=../OpenFAST/install/lib/cmake/OpenFAST cmake ..
+          make -j $(nproc)
+      - name: Build dummy-turbine fluid case
+        run: |
+          cd cases/dummy-turbine/fluid
+          cmake .
+          make -j $(nproc)
+      - name: Run dummy-turbine tutorial
+        run: |
+          cd cases/dummy-turbine/fluid
+          ./run.sh &
+          PIDOne=$!
+          cd ../openfast
+          PATH=../../build/:${PATH} ./run.sh &
+          PIDTwo=$!
+          wait $PIDOne
+          wait $PIDTwo

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ A more detailed description of the concept behind the adapter can be found in th
 
 ## License and attribution
 
-Parts of the code in `src/openfast-adapter` were reused from a [OpenFAST C++ API example](https://github.com/OpenFAST/openfast/tree/v3.5.0/glue-codes/openfast-cpp/src/FAST_Prog.cpp), which is licensed under the [Apache 2 license](https://github.com/LeonardWilleke/openfast-adapter/thirdparty/LICENSE.txt).
+Parts of the code in `src/openfast-adapter` were reused from a [OpenFAST C++ API example](https://github.com/OpenFAST/openfast/tree/v3.5.0/glue-codes/openfast-cpp/src/FAST_Prog.cpp), which is licensed under the [Apache 2 license](https://github.com/precice/openfast-adapter/tree/main/thirdparty).
 
 ## Development contribution
 


### PR DESCRIPTION
Adds a GitHub Actions workflow which (on push, pull request, or on demand):

- Gets a nightly preCICE container
- Builds OpenFAST 3.5.3
- Builds the adapter
- Runs the dummy-turbine case

edit: Already merged #5 here, since it is needed to build the adapter.