### PR TITLE
Deactivate library turbinesFoam

### DIFF
--- a/cases/cfd-turbine/fluid/system/controlDict
+++ b/cases/cfd-turbine/fluid/system/controlDict
@@ -49,7 +49,7 @@ maxCo           0.9;
 libs
 (
     // You might want to use the library turbinesFoam to implement actuator lines in OpenFOAM. See file "fvOptions" for input details.
-    //"libturbinesFoam.so"
+    // "libturbinesFoam.so"
 );
 
 functions

--- a/cases/cfd-turbine/fluid/system/fvOptions
+++ b/cases/cfd-turbine/fluid/system/fvOptions
@@ -16,6 +16,8 @@ FoamFile
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
 
+// Optional input for the library turbinesFoam
+/*
 turbine
 {
     type            axialFlowTurbineALSource;
@@ -141,5 +143,6 @@ turbine
         }
     }
 }
+*/
 
 // ************************************************************************* //


### PR DESCRIPTION
Deactivates the OpenFOAM library turbinesFoam in the [cfd-turbine](https://github.com/precice/openfast-adapter/tree/main/cases/cfd-turbine) case.

An alternative is to fully remove the `fvOptions` file.

Closes #3 